### PR TITLE
Speed up XCTrace conversion

### DIFF
--- a/.idea/codeStyles/Project.xml
+++ b/.idea/codeStyles/Project.xml
@@ -1,0 +1,10 @@
+<component name="ProjectCodeStyleConfiguration">
+  <code_scheme name="Project" version="173">
+    <JetCodeStyleSettings>
+      <option name="CODE_STYLE_DEFAULTS" value="KOTLIN_OFFICIAL" />
+    </JetCodeStyleSettings>
+    <codeStyleSettings language="kotlin">
+      <option name="CODE_STYLE_DEFAULTS" value="KOTLIN_OFFICIAL" />
+    </codeStyleSettings>
+  </code_scheme>
+</component>

--- a/.idea/codeStyles/codeStyleConfig.xml
+++ b/.idea/codeStyles/codeStyleConfig.xml
@@ -1,0 +1,5 @@
+<component name="ProjectCodeStyleConfiguration">
+  <state>
+    <option name="USE_PER_PROJECT_SETTINGS" value="true" />
+  </state>
+</component>

--- a/.idea/misc.xml
+++ b/.idea/misc.xml
@@ -1,4 +1,3 @@
-<?xml version="1.0" encoding="UTF-8"?>
 <project version="4">
   <component name="ExternalStorageConfigurationManager" enabled="true" />
   <component name="FrameworkDetectionExcludesConfiguration">

--- a/README.md
+++ b/README.md
@@ -30,7 +30,3 @@ Options:
 # Convert Instruments trace to Gecko on the second run within the trace file
 java -jar ./build/libs/instruments-to-gecko.jar --input example.trace --run 2 --app YourApp --output examplestandalone.json.gz
 ```
-
-## Known Issues
-
-* Conversion may be slow on larger files. No performance optimizations have been done on the conversion yet.


### PR DESCRIPTION
**Background**
https://github.com/benjaminRomano/instruments-to-gecko/issues/1
XCTrace conversion is slow because we re-perform look ups over large chunks of the XML tree for finding the original node given a reference node. 

This can be sped up by maintaining a cache of `tag:refId -> node`.

**Changes**
* Implement a `tag:refId -> node` cache.
* Furthermore, I found that we can further optimize by pre-computing the cache which avoids duplicate XML tree traversals

**Test Plan**
* Verified locally


This shaves off about 10s+ (15s -> 5s) for conversions.