### PR TITLE
Add retries for `xctrace` commands to avoid SIGSEV failures

### DIFF
--- a/src/main/java/com/bromano/instrumentsgecko/InstrumentsParser.kt
+++ b/src/main/java/com/bromano/instrumentsgecko/InstrumentsParser.kt
@@ -37,7 +37,7 @@ const val SYSCALL_SCHEMA = "syscall"
 
 private const val XCTRACE_RETRY_DELAY_MS = 500L
 
-// SIGSEV exit code. XCTrace periodically fails with transient errors
+// SIGSEV exit code. XCTrace can transiently fail with this exit code
 private const val SIGSEV_EXIT_CODE = 139
 
 private const val NUMBER_ATTR = "number"
@@ -383,7 +383,7 @@ object InstrumentsParser {
     private fun queryXCTraceTOC(input: Path): Document {
         val xmlStr = withRetry(
             delayMillis = XCTRACE_RETRY_DELAY_MS,
-            shouldRetry = { (it as? ShellCommandException)?.exitCode == SIGSEV_EXIT_CODE }
+            shouldRetry = { (it as? ShellCommandException)?.exitCode == 10 }
         ) {
             ShellUtils.run(
                 "xctrace export --input $input --toc",

--- a/src/main/java/com/bromano/instrumentsgecko/InstrumentsParser.kt
+++ b/src/main/java/com/bromano/instrumentsgecko/InstrumentsParser.kt
@@ -383,7 +383,7 @@ object InstrumentsParser {
     private fun queryXCTraceTOC(input: Path): Document {
         val xmlStr = withRetry(
             delayMillis = XCTRACE_RETRY_DELAY_MS,
-            shouldRetry = { (it as? ShellCommandException)?.exitCode == 10 }
+            shouldRetry = { (it as? ShellCommandException)?.exitCode == SIGSEV_EXIT_CODE }
         ) {
             ShellUtils.run(
                 "xctrace export --input $input --toc",

--- a/src/main/java/com/bromano/instrumentsgecko/InstrumentsParser.kt
+++ b/src/main/java/com/bromano/instrumentsgecko/InstrumentsParser.kt
@@ -368,6 +368,7 @@ object InstrumentsParser {
             ShellUtils.run(
                 "xctrace export --input $input --xpath '$xpath'",
                 redirectOutput = ProcessBuilder.Redirect.PIPE,
+                redirectError = ProcessBuilder.Redirect.PIPE,
                 shell = true
             )
         }
@@ -388,6 +389,7 @@ object InstrumentsParser {
             ShellUtils.run(
                 "xctrace export --input $input --toc",
                 redirectOutput = ProcessBuilder.Redirect.PIPE,
+                redirectError = ProcessBuilder.Redirect.PIPE,
                 shell = true
             )
         }

--- a/src/main/java/com/bromano/instrumentsgecko/ShellUtils.kt
+++ b/src/main/java/com/bromano/instrumentsgecko/ShellUtils.kt
@@ -1,7 +1,5 @@
 package com.bromano.instrumentsgecko
 
-import com.github.ajalt.clikt.core.CliktError
-import java.awt.Color.red
 import java.io.InputStream
 
 /**
@@ -60,8 +58,14 @@ class ShellUtils {
 
             if (exitCode != 0 && !ignoreErrors) {
                 val error = proc.errorStream.bufferedReader().readText().trim()
-                throw CliktError("Command failed: ${"$command\n$error"}")
+                throw ShellCommandException(command, exitCode, error)
             }
         }
     }
 }
+
+class ShellCommandException(
+    command: String,
+    val exitCode: Int,
+    stderr: String
+) : RuntimeException("Command, `$command`, failed with exit code $exitCode: $stderr")

--- a/src/main/java/com/bromano/instrumentsgecko/ShellUtils.kt
+++ b/src/main/java/com/bromano/instrumentsgecko/ShellUtils.kt
@@ -57,6 +57,7 @@ class ShellUtils {
             val exitCode = proc.waitFor()
 
             if (exitCode != 0 && !ignoreErrors) {
+                // Note: This is only populated with `ProcessBuilder.Redirect.PIPE`
                 val error = proc.errorStream.bufferedReader().readText().trim()
                 throw ShellCommandException(command, exitCode, error)
             }

--- a/src/main/java/com/bromano/instrumentsgecko/WithRetry.kt
+++ b/src/main/java/com/bromano/instrumentsgecko/WithRetry.kt
@@ -1,0 +1,38 @@
+package com.bromano.instrumentsgecko
+
+/**
+ * Executes [block] and retries it when an exception is thrown, up to [maxAttempts] times.
+ *
+ * @param maxAttempts total number of attempts; must be at least 1.
+ * @param delayMillis sleep duration in milliseconds between retries.
+ * @param shouldRetry predicate that decides whether the caught [Throwable] should trigger another attempt.
+ * @param block operation to run with retry semantics.
+ * @throws Throwable the last error encountered when retries are exhausted or `shouldRetry` returns false.
+ */
+inline fun <T> withRetry(
+    maxAttempts: Int = 3,
+    delayMillis: Long = 0,
+    shouldRetry: (Throwable) -> Boolean = { true },
+    block: () -> T
+): T {
+    require(maxAttempts >= 1) { "maxAttempts must be at least 1" }
+
+    var lastError: Throwable? = null
+    repeat(maxAttempts) { attemptIndex ->
+        try {
+            return block()
+        } catch (error: Throwable) {
+            lastError = error
+            val isLastAttempt = attemptIndex == maxAttempts - 1
+            if (!shouldRetry(error) || isLastAttempt) {
+                throw error
+            }
+
+            if (delayMillis > 0) {
+                Thread.sleep(delayMillis)
+            }
+        }
+    }
+
+    throw lastError ?: IllegalStateException("withRetry failed without executing block")
+}


### PR DESCRIPTION
**Background**
`xctrace` can fail with transient SIGSEVs. We should defensively guard against this until `xctrace` is patched. 

**Changes**
* Implement a `withRetry` utility to support generic capabilities
* Wrap `xctrace` command invocations with retries
* Implement `ShellCommandException` exception sub-class to propagate exit code for retry logic

**Test Plan**
I ran `instruments-to-gecko` with corrupted `trace` and file and forced retries on exit code 10 since simulating SIGSEV is difficult.

```
 ✘ benjaminromano  ~/Dev/instruments-to-gecko   bromano/succint-retries ●  java -jar ./build/libs/instruments-to-gecko.jar --input ~/Dev/mobileperf-cli/artifacts/trace_out/instruments-2025-10-03-15-39.trace --output example.out
Exception in thread "main" com.bromano.instrumentsgecko.ShellCommandException: Command, `xctrace export --input /Users/benjaminromano/Dev/mobileperf-cli/artifacts/trace_out/instruments-2025-10-03-15-39.trace --toc`, failed with exit code 10: Export failed: Document Missing Template Error
	at com.bromano.instrumentsgecko.ShellUtils$Companion.run(ShellUtils.kt:61)
	at com.bromano.instrumentsgecko.ShellUtils$Companion.run(ShellUtils.kt:18)
	at com.bromano.instrumentsgecko.ShellUtils$Companion.run$default(ShellUtils.kt:10)
	at com.bromano.instrumentsgecko.InstrumentsParser.queryXCTraceTOC(InstrumentsParser.kt:389)
	at com.bromano.instrumentsgecko.InstrumentsParser.getInstrumentsSettings(InstrumentsParser.kt:171)
	at com.bromano.instrumentsgecko.GeckoCommand.run(GeckoCommand.kt:70)
	at com.github.ajalt.clikt.parsers.Parser.parse(Parser.kt:198)
	at com.github.ajalt.clikt.parsers.Parser.parse(Parser.kt:18)
	at com.github.ajalt.clikt.core.CliktCommand.parse(CliktCommand.kt:400)
	at com.github.ajalt.clikt.core.CliktCommand.parse$default(CliktCommand.kt:397)
	at com.github.ajalt.clikt.core.CliktCommand.main(CliktCommand.kt:415)
	at com.github.ajalt.clikt.core.CliktCommand.main(CliktCommand.kt:440)
	at com.bromano.instrumentsgecko.GeckoCommandKt.main(GeckoCommand.kt:17)
```
